### PR TITLE
Correct licence in image label

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -83,7 +83,7 @@ jobs:
             ${{ steps.meta.outputs.labels }}
             "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
             "org.opencontainers.image.description=Gets public ip and writes to a database. Optionally notifies on change, and pings healthchecks.io"
-            "org.opencontainers.image.licenses=BSD-3-Clause"
+            "org.opencontainers.image.licenses=MIT"
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Push with alpha/beta/rc Tags


### PR DESCRIPTION
Fix incorrect licence being set in label `org.opencontainers.image.licenses` by [docker build action](.github/workflows/docker-build-publish.yml) 