### PR TITLE
Remove python test action run conditions

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     types:
      - synchronize
-    paths:
-      - src/*
-      - tests/*
   push:
     branches:
       - master

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     types:
      - synchronize
-    paths:
-      - '**.py'
   push:
     branches:
       - master


### PR DESCRIPTION
Always run python linting/tests, as now required to merge into branch `master`