### PR TITLE
Improve GitHub actions triggers

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -5,7 +5,6 @@ on:
      - opened
      - reopened
      - edited
-     - synchronize
 
 jobs:
   check-not-wip:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -2,6 +2,9 @@ name: Python Linting
 on:
   pull_request:
     types:
+     - opened
+     - reopened
+     - edited
      - synchronize
   push:
     branches:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,6 +2,9 @@ name: Python Tests
 on:
   pull_request:
     types:
+     - opened
+     - reopened
+     - edited
      - synchronize
   push:
     branches:


### PR DESCRIPTION
- Run linter and pytest on `opened`, `reopened` and `edited`
- Don't run WIP action on `synchronize`, it doesn't check for anything that changes with commits