### PR TITLE
Tidy release-drafter & dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,30 @@ version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
+    allow:
+      - dependency-type: production
+    labels:
+      - "dependencies:production"
+      - "python"
     schedule:
       interval: "weekly"
       day: "sunday"
+
+  # Python dev dependencies are separate so that they can have a different label
+  # This is then used by release-drafter
+  - package-ecosystem: "pip"
+    directory: "/"
+    allow:
+      - dependency-type: development
+    labels:
+      - "dependencies:development"
+      - "python"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      development-dependencies:
+        dependency-type: "development"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,10 +14,11 @@ categories:
       - 'documentation'
   - title: 'Updated Dependencies'
     labels:
-      - 'dependencies'
+      - 'dependencies:production'
   - title: 'Maintenance'
     labels:
       - 'maintenance'
+      - 'dependencies:development'
 
 change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'  # @$AUTHOR not used here, names in Contributors section
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
@@ -25,42 +26,32 @@ change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add
 version-resolver:
   major:
     labels:
-      - 'major'
+      - 'semver:major'
   minor:
     labels:
-      - 'minor'
-      - 'enhancement'
+      - 'semver:minor'
   patch:
     labels:
-      - 'patch'
-      - 'dependencies'
-      - 'bug'
+      - 'semver:patch'
   default: patch
 
 autolabeler:
   - label: 'maintenance'
-    files:
-      - '.github/*'
-      - '.vscode/*'
     branch:
-      - '/maintenance-.+/'
+      - '/chore-.+/'
   - label: 'documentation'
-    files:
-      - '*.md'
-      - 'docs/*'
     branch:
-      - '/docs.+/'
+      - '/docs-.+/'
   - label: 'bug'
     branch:
       - '/fix-.+/'
-    title:
-      - '/fix.+/'
+      - '/bugfix-.+/'
   - label: 'enhancement'
     branch:
       - '/feature-.+/'
       - '/feat-.+/'
 
 template: |
-  ## Changes
+  # Changes
 
   $CHANGES


### PR DESCRIPTION
- [x] Change labels used by release-drafter, to avoid collisions with dependabot
- [x] Use separate labels for production/development dependencies updated by dependabot, so that release drafter can differentiate