### PR TITLE
Auto-label development dependencies

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,6 +36,10 @@ version-resolver:
   default: patch
 
 autolabeler:
+  - label: 'dependencies:development'
+    branch:
+      - '/dependabot\/pip\/development-dependencies-.+/'
+      - '/dependabot\/github_actions/'
   - label: 'maintenance'
     branch:
       - '/chore-.+/'


### PR DESCRIPTION
Fix for dependabot PR integration, so release-drafter can identify production/development dependecies