### PR TITLE
Use ruff >=0.0.250

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pg8000 = "*"
 [tool.poetry.group.dev.dependencies]
 rope = "*"
 black = "*"
-ruff = "^0.0.250"
+ruff = ">=0.0.250"
 pytest = "*"
 isort = "*"
 pytest-cov = "*"


### PR DESCRIPTION
This is the earliest version to support structural pattern matching