### PR TITLE
Add support for Windows file paths in TestCustomNamer.test_actual()

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,9 +11,22 @@ from ipget.helpers import custom_namer
 
 @pytest.fixture
 def mock_datetime_now(monkeypatch):
+    """
+    Mocks the current datetime to a fixed value for testing purposes.
+
+    Args:
+        monkeypatch: The monkeypatch fixture provided by pytest.
+
+    Returns:
+        None
+    """
+
     class MockDatetime(datetime.datetime):
         @classmethod
         def now(cls):
+            """
+            Returns a fixed datetime representing 1963-11-23 17:16:00.
+            """
             return datetime.datetime(1963, 11, 23, 17, 16, 0)
 
     monkeypatch.setattr(datetime, "datetime", MockDatetime)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from pathlib import Path
 
 import pytest
@@ -21,9 +22,11 @@ def mock_datetime_now(monkeypatch):
 class TestCustomNamer:
     def test_actual(self, mock_datetime_now):
         default_log_file_name = "/app/logs/ipget.log"
-        # test_date = datetime(1963, 11, 23, 17, 16, 0)
         new_file_name = custom_namer(default_log_file_name)
-        assert new_file_name == "/app/logs/ipget.1963-11-23.log"
+        if os.name == "nt":
+            assert new_file_name == "C:\\app\\logs\\ipget.1963-11-23.log"
+        else:
+            assert new_file_name == "/app/logs/ipget.1963-11-23.log"
 
     @given(
         stem=st.text(min_size=1, alphabet=st.characters(categories=["L", "N", "S"])),


### PR DESCRIPTION
This pull request adds support for Windows file paths in the TestCustomNamer.test_actual() method. It includes changes to handle file paths differently based on the operating system.