### PR TITLE
Remove GitHubSecurityLab actions-permissions monitor step and set permissions explicitly

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -14,6 +14,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions: {}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -22,10 +24,6 @@ jobs:
       packages: write
 
     steps:
-      # https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
       # Get repo, python, and poetry
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request removes the GitHubSecurityLab actions-permissions monitor step from the docker-build-publish workflow and sets the permissions explicitly. This change ensures that the permissions are defined clearly and ensures the workflow has the minimum required permissions.