### PR TITLE
Update dependency groups and add Devcontainers dependency update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "devcontainers"
+    # https://containers.dev/guide/dependabot
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "sunday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,14 @@ updates:
     groups:
       development-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "ruff"
+          - "mypy"
+          - "pytest"
+
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,3 +35,6 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
- Updates the dependency groups to include *only* minor and patch updates
- Adds a weekly update schedule for Devcontainers dependencies.
- Exclude `ruff`, `mypy` and `pytest` from the python `development-dependencies` group, as these are used in required PR checks