### PR TITLE
Update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0 # Use the sha / tag you want to point at
+    rev: v4.6.0 # Use the sha / tag you want to point at
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -25,7 +25,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.5
+    rev: v0.4.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -34,7 +34,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.22.0
+    rev: v1.26.0
     hooks:
       - id: ggshield
         language_version: python3


### PR DESCRIPTION
This pull request updates the pre-commit hooks to their latest versions. 

Specifically: 

- the `pre-commit-hooks` repository is updated to version `4.6.0` 
- the `ruff-pre-commit` repository is updated to version `0.4.1`
- the `ggshield` repository is updated to version `1.26.0` 