### PR TITLE
Fix Python dependency labels in GitHub Actions workflow

### DIFF
--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -37,7 +37,6 @@ jobs:
         run: gh pr edit "${{env.PR_URL}}" --add-label "${{env.LABEL_SEMVER_DEFAULT}}"
 
       # Python Dependencies
-
       - name: Determine if development or production
         id: determine-python-label
         if: steps.metadata.outputs.package-ecosystem == 'pip'

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Determine if development or production
         id: determine-python-label
         if: steps.metadata.outputs.package-ecosystem == 'pip'
-        # Check if the github ref containd 'devlopment', or
+        # Check if the github ref containd 'development', or
         # Ruff, mypy, pytest, which are development dependencies,
         # but they are not in the development-dependencies group
         run: |

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -47,7 +47,8 @@ jobs:
         run: |
           if [[ ${{ github.head_ref }} == *dependabot/pip/development-dependencies* ]]; then
             echo "py-dep-type=development" >> "$GITHUB_OUTPUT"
-          elif [[ ${{ github.head_ref }} == *ruff* ]] || [[ ${{ github.head_ref }} == *mypy* ]] || [[ ${{ github.head_ref }} == *pytest* ]]; then
+          elif [[ ${{ github.head_ref }} =~ ^.*\/(ruff|mypy|pytest)-.*$ ]]; then
+            echo "py-dep-type=development" >> "$GITHUB_OUTPUT"
             echo "py-dep-type=development" >> "$GITHUB_OUTPUT"
           else
             echo "py-dep-type=production" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -37,14 +37,30 @@ jobs:
         run: gh pr edit "${{env.PR_URL}}" --add-label "${{env.LABEL_SEMVER_DEFAULT}}"
 
       # Python Dependencies
+
+      - name: Determine if development or production
+        id: determine-python-label
+        if: steps.metadata.outputs.package-ecosystem == 'pip'
+        # Check if the github ref containd 'devlopment', or
+        # Ruff, mypy, pytest, which are development dependencies,
+        # but they are not in the development-dependencies group
+        run: |
+          if [[ ${{ github.head_ref }} == *dependabot/pip/development-dependencies* ]]; then
+            echo "py-dep-type=development" >> "$GITHUB_OUTPUT"
+          elif [[ ${{ github.head_ref }} == *ruff* ]] || [[ ${{ github.head_ref }} == *mypy* ]] || [[ ${{ github.head_ref }} == *pytest* ]]; then
+            echo "py-dep-type=development" >> "$GITHUB_OUTPUT"
+          else
+            echo "py-dep-type=production" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Python Production
         id: label-python-production
-        if: steps.metadata.outputs.package-ecosystem == 'pip' && startsWith(github.head_ref, 'dependabot/pip/development-dependencies') == false
+        if: steps.metadata.outputs.package-ecosystem == 'pip' && steps.determine-python-label.outputs.py-dep-type == 'production'
         run: gh pr edit "${{env.PR_URL}}" --add-label "${{env.LABEL_PRODUCTION}}"
 
       - name: Python Development
         id: label-python-development
-        if: steps.metadata.outputs.package-ecosystem == 'pip' && startsWith(github.head_ref, 'dependabot/pip/development-dependencies')
+        if: steps.metadata.outputs.package-ecosystem == 'pip' && steps.determine-python-label.outputs.py-dep-type == 'development'
         run: gh pr edit "${{env.PR_URL}}" --add-label "${{env.LABEL_DEVELOPMENT}}"
 
       # GitHub Actions Dependencies


### PR DESCRIPTION
This pull request fixes the labels for Python dependencies in the GitHub Actions workflow. 

Previously, as a result of severeal dev dependencies being removed from the  development-dependencies group, the labels were not being set correctly on dependabot PRs updating them. 

This PR adds a new step to better determine the type of dependencies and set the labels accordingly.