### PR TITLE
Replace random.choice with st.sampled_from in custom strategies

### DIFF
--- a/src/ipget/custom_strategies.py
+++ b/src/ipget/custom_strategies.py
@@ -1,5 +1,3 @@
-import random
-
 from hypothesis import strategies as st
 
 
@@ -22,5 +20,5 @@ def _generate_casing_variations(input_string: str):
 
 @st.composite
 def random_casing(draw: st.DrawFn, string_list: list[str]):
-    rand_level = random.choice(string_list)
+    rand_level = draw(st.sampled_from(string_list))
     return draw(st.sampled_from(_generate_casing_variations(rand_level)))


### PR DESCRIPTION
`HypothesisDeprecationWarning: Do not use the random module inside strategies; instead consider st.randoms(), st.sampled_from()`

## Summary by Sourcery

Enhancements:
- Replace usage of random.choice with st.sampled_from in the random_casing strategy to adhere to Hypothesis best practices.