### PR TITLE
Fix #304 docker matchManager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,11 +53,11 @@
       "addLabels": ["github_actions", "maintenance"]
     },
     {
-      "matchManagers": ["docker", "docker-compose", "dockerfile"],
+      "matchManagers": ["docker-compose", "dockerfile"],
       "addLabels": ["dependencies"]
     },
     {
-      "matchManagers": ["docker", "docker-compose", "dockerfile"],
+      "matchManagers": ["docker-compose", "dockerfile"],
       "matchPackageNames": ["python"],
       "enabled": false
     }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove 'docker' from the matchManagers list in renovate.json to fix incorrect label application.