### PR TITLE
Add pre-commit hooks and automate PR labeling for pre-commit-ci bot

### DIFF
--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -16,6 +16,14 @@ permissions:
   pull-requests: write
 
 jobs:
+  pre-commit-ci-labler:
+    runs-on: ubuntu-latest
+    if: github.actor == 'pre-commit-ci[bot]'
+    steps:
+      - name: Add semver:patch label
+        id: label-maintenance
+        run: gh pr edit "${{env.PR_URL}}" --add-label "maintenance"
+
   dependabot-labeler:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -24,6 +24,10 @@ jobs:
         id: label-maintenance
         run: gh pr edit "${{env.PR_URL}}" --add-label "maintenance"
 
+      - name: Assign maintainer
+        id: assign-maintainer
+        run: gh pr edit "${{env.PR_URL}}" --add-assignee "LunaPurpleSunshine"
+
   dependabot-labeler:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -24,9 +24,9 @@ jobs:
         id: label-maintenance
         run: gh pr edit "${{env.PR_URL}}" --add-label "maintenance"
 
-      - name: Assign maintainer
-        id: assign-maintainer
-        run: gh pr edit "${{env.PR_URL}}" --add-assignee "LunaPurpleSunshine"
+      - name: Assign owner
+        id: assign-owner
+        run: gh pr edit "${{env.PR_URL}}" --add-assignee "${{ github.repository_owner }}"
 
   dependabot-labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Dependabot Labeler
+name: PR Auto-Manager
 on:
   pull_request:
     types:
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  pre-commit-ci-labler:
+  pre-commit-ci:
     runs-on: ubuntu-latest
     if: github.actor == 'pre-commit-ci[bot]'
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
     rev: v5.0.0 # Use the sha / tag you want to point at
     hooks:
       - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
       - id: check-merge-conflict
       - id: debug-statements
       - id: detect-private-key


### PR DESCRIPTION
## Summary by Sourcery

Automate the labeling and assignment of pull requests from the pre-commit-ci bot in the GitHub Actions workflow and enhance the pre-commit configuration by adding new hooks for checking case conflicts and illegal Windows filenames.

Enhancements:
- Introduce additional pre-commit hooks to check for case conflicts and illegal Windows filenames.

CI:
- Add a new job in the GitHub Actions workflow to automatically label pull requests from the pre-commit-ci bot as 'maintenance' and assign them to a specific maintainer.