### PR TITLE
Update semver labels applied to PRs for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,18 +29,12 @@
       "matchManagers": ["pep621"],
       "matchDepTypes": ["project.dependencies"],
       "matchUpdateTypes": ["major"],
-      "addLabels": ["semver:major"]
-    },
-    {
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "matchUpdateTypes": ["minor"],
       "addLabels": ["semver:minor"]
     },
     {
       "matchManagers": ["pep621"],
       "matchDepTypes": ["project.dependencies"],
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["semver:patch"]
     },
     {


### PR DESCRIPTION
Update the semver labels in the renovate.json configuration to apply `semver:patch` to both minor and patch updates, and remove the separate label for major updates, applying `semver:minor` label to major updates instead