### PR TITLE
Update Renovate configuration

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -86,6 +86,16 @@ jobs:
         if: steps.metadata.outputs.package-ecosystem == 'github-actions'
         run: gh pr edit "${{env.PR_URL}}" --add-label "${{env.LABEL_DEVELOPMENT}}"
 
+  renovate:
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]'
+    steps:
+      - name: Label Lock file maintenance
+        id: label-lock-file-maintenance
+        # Only run if the PR title contains "Lock file"
+        if: contains(github.event.pull_request.title, 'Lock file')
+        run: gh pr edit "${{env.PR_URL}}" --add-label "semver:patch"
+
   check-labels:
     # This job should run, even if the previous jobs failed or were skipped,
     # but MUST run after them, if they are not skipped.
@@ -93,6 +103,7 @@ jobs:
     needs:
       - pre-commit-ci
       - dependabot
+      - renovate
     if: ${{ ! cancelled() }}
     steps:
       - name: Check semver label

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "schedule": [
+    "every weekend"
+  ],
   "assignees": ["LunaPurpleSunshine"],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
- [x] Shedule renovate to open dep update PRs only at the weekend.
- [x] Add PR Manager job to auto-tag lock file updates

## Summary by Sourcery

Update the Renovate configuration to schedule dependency update pull requests for weekends and add a CI job to auto-label lock file maintenance PRs with 'semver:patch'.

Enhancements:
- Schedule Renovate to open dependency update pull requests only on weekends.

CI:
- Add a job to automatically label lock file maintenance pull requests with 'semver:patch' when opened by Renovate.