### PR TITLE
Remove debug logging from PR Manager workflow

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -106,11 +106,6 @@ jobs:
       - renovate
     if: ${{ ! cancelled() }}
     steps:
-      - name: Debug show PR author & actor
-        run: |
-          echo "Author: ${{ github.event.pull_request.user.login }}"
-          echo "Actor: ${{ github.actor }}"
-
       - name: Check semver label
         id: semver_label_check
         uses: agilepathway/label-checker@v1.6.56


### PR DESCRIPTION
Remove debug logging added in #342 from PR Manager workflow, once it works with both bots.

- [x] pre-commit-ci[bot]
- [x] renovate[bot]

## Summary by Sourcery

CI:
- Remove debug logging from the PR Manager workflow.

## Summary by Sourcery

CI:
- Remove debug logging from the PR Manager workflow.