### PR TITLE
Use an environment variable for UV version in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '26 23 * * 3'
 
+env:
+  # renovate: datasource=github-releases depName=uv packageName=astral-sh/uv
+  UV_VERSION: "0.4.20"
+
 jobs:
   analyze:
     name: Analyze
@@ -55,7 +59,7 @@ jobs:
       if: matrix.language == 'python'
       with:
         # Install a specific version of uv.
-        version: "0.4.20"
+        version: ${{env.UV_VERSION}}
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - master
 
+env:
+  # renovate: datasource=github-releases depName=uv packageName=astral-sh/uv
+  UV_VERSION: "0.4.20"
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
@@ -28,8 +32,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          # Install a specific version of uv.
-          version: "0.4.20"
+          version: ${{env.UV_VERSION}}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
@@ -60,8 +63,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          # Install a specific version of uv.
-          version: "0.4.20"
+          version: ${{env.UV_VERSION}}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
@@ -88,8 +90,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          # Install a specific version of uv.
-          version: "0.4.20"
+          version: ${{env.UV_VERSION}}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 


### PR DESCRIPTION
Use an environment variable to manage the UV version across workflows, improving maintainability and consistency.

## Summary by Sourcery

CI:
- Set the UV version via the `UV_VERSION` environment variable.