### PR TITLE
Add concurrency control to manage-pull-requests workflow

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -11,7 +11,7 @@ on:
 
 # Since this workflow is triggered by ALL changes to labels,
 # we only want to let the most recent one run.
-# This avoids issues when multiple labesl are added/removed at the same time.
+# This avoids issues when multiple labels are added/removed at the same time.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id}}
   cancel-in-progress: true

--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -9,6 +9,13 @@ on:
       - edited
       - synchronize
 
+# Since this workflow is triggered by ALL changes to labels,
+# we only want to let the most recent one run.
+# This avoids issues when multiple labesl are added/removed at the same time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id}}
+  cancel-in-progress: true
+
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Implement concurrency control to ensure that only the most recent workflow runs when multiple label changes occur simultaneously. This prevents conflicts and improves efficiency, particularly in the slow `agilepathway/label-checker` step.

## Summary by Sourcery

CI:
- Prevent concurrent workflow runs by canceling any in-progress runs when a new workflow is triggered by a label change.