### PR TITLE
Update Renovate configuration to improve automatic labeling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,10 +59,13 @@
       "addLabels": ["semver:minor"]
     },
     {
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["!major"],
       "addLabels": ["semver:patch"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "matchDepTypes": ["!tool.uv.dev-dependencies"],
+      "addLabels": ["semver:minor"]
     },
     {
       "matchManagers": ["pep621"],

--- a/renovate.json
+++ b/renovate.json
@@ -59,11 +59,15 @@
       "addLabels": ["semver:minor"]
     },
     {
-      "matchUpdateTypes": ["!major"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
       "addLabels": ["semver:patch"]
     },
     {
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["pinDigest"],
+      "addLabels": ["maintenance"]
+    },
+    {
+      "matchUpdateTypes": ["major", "replacement"],
       "matchDepTypes": ["!tool.uv.dev-dependencies"],
       "addLabels": ["semver:minor"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -22,23 +22,27 @@
     "automerge": true
     },
     {
-      "matchManagers": ["github-actions"],
-      "addLabels": ["github_actions", "maintenance"],
-      "semanticCommitType": "ci",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "matchManagers": ["docker-compose", "dockerfile"],
-      "addLabels": ["dependencies"]
-    },
-    {
       "matchManagers": ["docker-compose", "dockerfile"],
       "matchPackageNames": ["python"],
       "enabled": false
     },
     {
+      "matchManagers": ["github-actions"],
+      "labels": ["github_actions", "maintenance"],
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "labels": ["dependencies", "semver:patch"]
+    },
+    {
+      "matchManagers": ["pep621"],
+      "addLabels": ["python"]
+    },
+    {
       "matchDepTypes": ["project.dependencies", "tool.uv.dev-dependencies"],
-      "labels": ["dependencies"]
+      "addLabels": ["dependencies"]
     },
     {
       "matchDepTypes": ["project.dependencies", "!tool.uv.dev-dependencies"],
@@ -49,22 +53,12 @@
       "addLabels": ["dependencies:development"]
     },
     {
-      "matchManagers": ["pep621"],
-      "addLabels": ["python"]
-    },
-    {
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["project.dependencies"],
-      "matchUpdateTypes": ["major"],
-      "addLabels": ["semver:minor"]
+      "matchUpdateTypes": ["pinDigest"],
+      "addLabels": ["maintenance"]
     },
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
       "addLabels": ["semver:patch"]
-    },
-    {
-      "matchUpdateTypes": ["pinDigest"],
-      "addLabels": ["maintenance"]
     },
     {
       "matchUpdateTypes": ["major", "replacement"],
@@ -72,9 +66,9 @@
       "addLabels": ["semver:minor"]
     },
     {
-      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["major", "replacement"],
       "matchDepTypes": ["tool.uv.dev-dependencies"],
-      "addLabels": ["semver:patch"]
+      "addLabels": ["semver:minor"]
     }
   ]
 }


### PR DESCRIPTION
Enhance the Renovate configuration to include patch and minor labels for non-pep621 managers.

## Summary by Sourcery

CI:
- Add patch and minor labels for non-pep621 managers.