### PR TITLE
fix(workflow): pre-commit-ci in PR Manager workflow

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -9,13 +9,6 @@ on:
       - edited
       - synchronize
 
-# Since this workflow is triggered by ALL changes to labels,
-# we only want to let the most recent one run.
-# This avoids issues when multiple labels are added/removed at the same time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id}}
-  cancel-in-progress: true
-
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PR_URL: ${{github.event.pull_request.html_url}}
@@ -111,13 +104,13 @@ jobs:
       - pre-commit-ci
       - dependabot
       - renovate
-    if: ${{ ! cancelled() }}
     steps:
       - name: Check semver label
         id: semver_label_check
         uses: agilepathway/label-checker@v1.6.65
         # Ignore documentation and repository maintenance PRs, as they are should not bump the semver
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'documentation') && !contains(github.event.pull_request.labels.*.name, 'maintenance')}}
+        # Also ignore PRs from pre-commit-ci, as the label adding still fails the check
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'documentation') && !contains(github.event.pull_request.labels.*.name, 'maintenance') && !contains(github.event.pull_request.user.login, 'pre-commit-ci[bot]') }}
         with:
           prefix_mode: true
           one_of: "semver:"


### PR DESCRIPTION
Ignore PRs from the pre-commit-ci bot and remove unnecessary concurrency settings, as they did not fix the underlying issue with the label added by one step not being seen by the next, resulting in the workflow failing incorrectly.