### PR TITLE
chore(ci): Add scheduled publishing

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,7 @@ categories:
     labels:
       - 'dependencies:production'
   - title: 'Maintenance'
+    collapse-after: 1
     labels:
       - 'maintenance'
       - 'dependencies:development'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,9 +17,6 @@ on:
   # pull_request_target:
   #   types: [opened, reopened, synchronize]
 
-permissions:
-  contents: read
-
 jobs:
   update_release_draft:
     permissions:
@@ -31,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - name: Create Draft Release
+        id: create_release
+        uses: release-drafter/release-drafter@v6
         with:
           commitish: master
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,8 @@ on:
   # pull_request_target event is required for autolabeler to support PRs from forks
   # pull_request_target:
   #   types: [opened, reopened, synchronize]
+  schedule:
+    - cron: "0 9 * * 1"
 
 jobs:
   update_release_draft:
@@ -26,6 +28,9 @@ jobs:
       # otherwise, read permission is required at least
       pull-requests: write
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.create_release.outputs.tag_name }}
+      body: ${{ steps.create_release.outputs.body }}
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Create Draft Release
@@ -35,3 +40,41 @@ jobs:
           commitish: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish_release:
+    # Only run this job on the scheduled cron job, not on pushes or PRs
+    if: ${{ github.event_name == 'schedule' }}
+    needs: update_release_draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # for gh actions to create a release
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check Release
+        id: check_release
+        run: |
+          echo "${{ needs.update_release_draft.outputs.body }}" >> ./body.txt
+          # Check if there is a draft release and exit if not
+          draft=$(gh release view ${{ needs.update_release_draft.outputs.tag_name }} --json isDraft --jq '.isDraft' --repo ${{ github.repository }})
+          do_release_check=false
+          if [ "$draft" != "true" ]; then
+            echo "No draft release to publish"
+            do_release_check=false
+            # Check if the body contains "No changes" and exit if so
+          elif [ "$(cat ./body.txt | grep -c "* No changes")" != "0" ]; then
+            echo "No changes to publish"
+            do_release_check=false
+          else
+            do_release_check=true
+          fi
+          echo "do_release=$do_release_check"
+          echo "do_release=$do_release_check" >> $GITHUB_OUTPUT
+
+      - name: Publish Release
+        id: publish_release
+        if: ${{ steps.check_release.outputs.do_release == 'true' }}
+        run: |
+          echo "Publishing draft release ${{ needs.update_release_draft.outputs.tag_name }}"
+          gh release edit ${{ needs.update_release_draft.outputs.tag_name }} --draft=false --repo ${{ github.repository }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -63,7 +63,7 @@ jobs:
             echo "No draft release to publish"
             do_release_check=false
             # Check if the body contains "No changes" and exit if so
-          elif [ "$(cat ./body.txt | grep -c "* No changes")" != "0" ]; then
+          elif [ "$(cat ./body.txt | grep -c "\* No changes")" != "0" ]; then
             echo "No changes to publish"
             do_release_check=false
           else


### PR DESCRIPTION
- Set `collapse-after` setting for the Maintenance category, to reduce noise from updated dev dependencies. 
- Update permissions and streamline the draft release process. 
- Add a scheduled job to automatically publish releases on Mondays, if there is a suitable draft.

## Summary by Sourcery

Enhance release management workflow by adding scheduled release publishing and improving release draft configuration

CI:
- Add a scheduled GitHub Actions workflow to automatically publish draft releases on Mondays
- Update release drafter workflow to support automatic release publishing checks

Chores:
- Configure Maintenance category to collapse after one item to reduce noise from dependency updates