### PR TITLE
chore(renovate): Update renovate labels

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,9 +13,6 @@ on:
      - opened
      - reopened
      - synchronize
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
   schedule:
     - cron: "0 9 * * 1"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,9 @@ repos:
       - id: ggshield
         language_version: python3
         stages: [pre-commit]
+
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 39.241.1
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict]

--- a/renovate.json
+++ b/renovate.json
@@ -57,8 +57,12 @@
       "addLabels": ["maintenance"]
     },
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "rollback", "bump"],
       "addLabels": ["semver:patch"]
+    },
+    {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "addlabels": ["maintenance"]
     },
     {
       "matchUpdateTypes": ["major", "replacement"],

--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,7 @@
     },
     {
       "matchManagers": ["docker-compose", "dockerfile"],
-      "labels": ["dependencies", "semver:patch"]
+      "labels": ["dependencies", "dependencies:production", "semver:patch"]
     },
     {
       "matchManagers": ["pep621"],

--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,8 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-    "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
-    "automerge": true
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
+      "automerge": true
     },
     {
       "matchManagers": ["docker-compose", "dockerfile"],
@@ -62,7 +62,7 @@
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
-      "addlabels": ["maintenance"]
+      "labels": ["python","dependencies", "maintenance"]
     },
     {
       "matchUpdateTypes": ["major", "replacement"],


### PR DESCRIPTION
- Update labels for `docker-compose`, `dockerfile`, and `lockFileMaintenance` updates in the renovate configuration.
- Remove unnecessary commented-out event in the CI configuration 