### PR TITLE
ci: Use custom PAT for release publishing

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       contents: write  # for gh actions to create a release
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.IPGET_PUBLISH_TOKEN }}
 
     steps:
       - name: Check Release


### PR DESCRIPTION
Switch to a custom Personal Access Token (PAT) for publishing releases to enable workflow triggers, replacing the default GITHUB_TOKEN.

See Docs [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

## Summary by Sourcery

CI:
- Replace default GITHUB_TOKEN with custom IPGET_PUBLISH_TOKEN for release publishing