### PR TITLE
ci: Update cron schedules to move to monthly updates/releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ on:
      - reopened
      - synchronize
   schedule:
-    - cron: "0 9 * * 1"
+    - cron: "0 9 5 * *"
 
 jobs:
   update_release_draft:

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "platformAutomerge": true,
   "semanticCommits": "enabled",
   "schedule": [
-    "every weekend"
+    "* 9 1-3 * *"
   ],
   "assignees": ["LunaPurpleSunshine"],
   "lockFileMaintenance": {


### PR DESCRIPTION
Adjust schedules for:

- Schedule Renovate to run on the 1st to 3rd of each month 
- Schedule release to run on the 5th of each month

## Summary by Sourcery

Update cron schedules for Renovate and release-drafter workflows to run on specific days each month

CI:
- Schedule Renovate to run on the 1st through 3rd of each month
- Schedule release-drafter to run on the 5th of each month