### PR TITLE
chore: Update and tidy pyptoject.toml

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,7 +37,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: uv install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --group dev
 
       - name: Linter
         # Update output format to enable automatic inline annotations.
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: uv install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --group dev
 
       - name: Run mypy
         run: uv run mypy src/ tests/
@@ -95,7 +95,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: uv install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --group dev --group ci
 
       # Run python tests
       - name: Run pytest

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -37,6 +37,7 @@ words:
   - psycopg
   - pydantic
   - pymysql
+  - pyproject
   - pytest
   - regen
   - setenv
@@ -50,6 +51,7 @@ words:
   - virtualenvs
   - VisualStudioExptTeam
   - vscodeintellicode
+  - xfail
   - yzhang
 ignoreWords: []
 import: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = ">=3.13"
+requires-python = ">=3.13, <3.14"
 name = "ipget"
 version = "0.11.0"
 description = "Gets public ip and writes to a database. Optionally notifies on change, and pings healthchecks.io."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,20 +19,38 @@ dependencies = [
     "sqlalchemy ==2.0.41",
 ]
 
-[tool.uv]
-dev-dependencies = [
-    "rope == 1.13.0",
-    "ruff ==0.11.13",
-    "pytest ==8.4.0",
-    "pytest-cov ==6.1.1",
-    "pre-commit ==4.2.0",
-    "pytest-md == 0.2.0",
-    "pytest-emoji == 0.2.0",
-    "python-dotenv ==1.1.0",
-    "hypothesis ==6.135.2",
-    "mypy ==1.16.0",
-    "types-requests ==2.32.0.20250602",
+[dependency-groups]
+dev = [
+    { include-group = "tools" },
+    { include-group = "lint" },
+    { include-group = "test" },
 ]
+tools = [
+    "pre-commit>=4.2.0",
+    "rope>=1.13.0",
+]
+lint = [
+    "mypy>=1.16.0",
+    "ruff==0.11.13",
+    "types-requests>=2.32.0.20250602",
+]
+test = [
+    "hypothesis>=6.135.2",
+    "pytest>=8.4.0",
+    "pytest-cov>=6.1.1",
+    "pytest-emoji>=0.2.0",
+    "pytest-md>=0.2.0",
+    "python-dotenv>=1.1.0",
+]
+ci = [
+    { include-group = "lint" },
+    { include-group = "test" },
+    "pytest-emoji>=0.2",
+    "pytest-md>=0.2",
+]
+
+
+######### Lint/Formatter Settings #########
 
 [tool.pytest.ini_options]
 pythonpath = "src/"
@@ -47,7 +65,7 @@ source = ["src/ipget"]
 src = ["src"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "B", "RUF", "TID252"]
+select = ["E", "F", "I", "B", "BLE", "A", "RUF", "TID252"]
 
 [tool.mypy]
 mypy_path = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ description = "Gets public ip and writes to a database. Optionally notifies on c
 authors = [{ name = "Andrew Kinsman", email = "69199502+LunaPurpleSunshine@users.noreply.github.com" }]
 license = {file = "LICENCE.txt"}
 readme = "README.md"
+classifiers = [
+    "Private :: Do Not Upload",
+]
 
 dependencies = [
     "discord-webhook ==1.4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ lint = [
     "types-requests>=2.32.0.20250602",
 ]
 test = [
+    "freezegun>=1.5.2",
     "hypothesis>=6.135.2",
     "pytest>=8.4.0",
     "pytest-cov>=6.1.1",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -71,9 +71,19 @@ class TestCustomNamer:
     )
     def test_multiple_suffixes(self, stem, suffix):
         assume(all([stem, suffix]))
+        assume(suffix != "log")  # Duplicate "log" suffixes are deliberately removed
 
         input_name = f"{stem}.{suffix}.{suffix}"
         expected_output = f"{stem}.{suffix}.{datetime.datetime.now().date()}.log"
+
+        result = custom_namer(input_name)
+
+        assert Path(result).name == expected_output
+
+    @given(st.integers(min_value=2, max_value=10))
+    def test_multiple_log_suffixes(self, suffix_multiplier: int):
+        input_name = "ipget" + ".log" * suffix_multiplier
+        expected_output = f"ipget.{datetime.datetime.now().date()}.log"
 
         result = custom_namer(input_name)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 from hypothesis import assume, example, given
 from hypothesis import strategies as st
 
@@ -74,18 +75,20 @@ class TestCustomNamer:
         assume(suffix != "log")  # Duplicate "log" suffixes are deliberately removed
 
         input_name = f"{stem}.{suffix}.{suffix}"
-        expected_output = f"{stem}.{suffix}.{datetime.datetime.now().date()}.log"
 
-        result = custom_namer(input_name)
+        with freeze_time("1963-11-23 17:15"):
+            expected_output = f"{stem}.{suffix}.{datetime.datetime.now().date()}.log"
+            result = custom_namer(input_name)
 
         assert Path(result).name == expected_output
 
     @given(st.integers(min_value=2, max_value=10))
     def test_multiple_log_suffixes(self, suffix_multiplier: int):
         input_name = "ipget" + ".log" * suffix_multiplier
-        expected_output = f"ipget.{datetime.datetime.now().date()}.log"
 
-        result = custom_namer(input_name)
+        with freeze_time("1963-11-23 17:15"):
+            expected_output = f"ipget.{datetime.datetime.now().date()}.log"
+            result = custom_namer(input_name)
 
         assert Path(result).name == expected_output
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -4,7 +4,7 @@ from os import environ
 
 import pytest
 from pytest import MonkeyPatch
-from requests import ConnectionError, HTTPError, Response
+from requests import ConnectionError, HTTPError, Response  # noqa: A004
 
 from ipget.environment import DISCORD_WEBHOOK_ENV
 from ipget.errors import ConfigurationError

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13"
+requires-python = "==3.13.*"
 
 [[package]]
 name = "annotated-types"
@@ -154,13 +154,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
     { url = "https://files.pythonhosted.org/packages/86/94/1fc0cc068cfde885170e01de40a619b00eaa8f2916bf3541744730ffb4c3/greenlet-3.2.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:024571bbce5f2c1cfff08bf3fbaa43bbc7444f580ae13b0099e95d0e6e67ed36", size = 1147121, upload-time = "2025-06-05T16:12:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/27/1a/199f9587e8cb08a0658f9c30f3799244307614148ffe8b1e3aa22f324dea/greenlet-3.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5195fb1e75e592dd04ce79881c8a22becdfa3e6f500e7feb059b1e6fdd54d3e3", size = 297603, upload-time = "2025-06-05T16:20:12.651Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
-    { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
-    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
-    { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
 ]
 
 [[package]]
@@ -217,6 +210,17 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+ci = [
+    { name = "hypothesis" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-emoji" },
+    { name = "pytest-md" },
+    { name = "python-dotenv" },
+    { name = "ruff" },
+    { name = "types-requests" },
+]
 dev = [
     { name = "hypothesis" },
     { name = "mypy" },
@@ -230,6 +234,23 @@ dev = [
     { name = "ruff" },
     { name = "types-requests" },
 ]
+lint = [
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-requests" },
+]
+test = [
+    { name = "hypothesis" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-emoji" },
+    { name = "pytest-md" },
+    { name = "python-dotenv" },
+]
+tools = [
+    { name = "pre-commit" },
+    { name = "rope" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -242,18 +263,46 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "hypothesis", specifier = "==6.135.2" },
-    { name = "mypy", specifier = "==1.16.0" },
-    { name = "pre-commit", specifier = "==4.2.0" },
-    { name = "pytest", specifier = "==8.4.0" },
-    { name = "pytest-cov", specifier = "==6.1.1" },
-    { name = "pytest-emoji", specifier = "==0.2.0" },
-    { name = "pytest-md", specifier = "==0.2.0" },
-    { name = "python-dotenv", specifier = "==1.1.0" },
-    { name = "rope", specifier = "==1.13.0" },
+ci = [
+    { name = "hypothesis", specifier = ">=6.135.2" },
+    { name = "mypy", specifier = ">=1.16.0" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-emoji", specifier = ">=0.2" },
+    { name = "pytest-md", specifier = ">=0.2" },
+    { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "ruff", specifier = "==0.11.13" },
-    { name = "types-requests", specifier = "==2.32.0.20250602" },
+    { name = "types-requests", specifier = ">=2.32.0.20250602" },
+]
+dev = [
+    { name = "hypothesis", specifier = ">=6.135.2" },
+    { name = "mypy", specifier = ">=1.16.0" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-emoji", specifier = ">=0.2.0" },
+    { name = "pytest-md", specifier = ">=0.2.0" },
+    { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "rope", specifier = ">=1.13.0" },
+    { name = "ruff", specifier = "==0.11.13" },
+    { name = "types-requests", specifier = ">=2.32.0.20250602" },
+]
+lint = [
+    { name = "mypy", specifier = ">=1.16.0" },
+    { name = "ruff", specifier = "==0.11.13" },
+    { name = "types-requests", specifier = ">=2.32.0.20250602" },
+]
+test = [
+    { name = "hypothesis", specifier = ">=6.135.2" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-emoji", specifier = ">=0.2.0" },
+    { name = "pytest-md", specifier = ">=0.2.0" },
+    { name = "python-dotenv", specifier = ">=1.1.0" },
+]
+tools = [
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "rope", specifier = ">=1.13.0" },
 ]
 
 [[package]]
@@ -629,7 +678,7 @@ name = "sqlalchemy"
 version = "2.0.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424, upload-time = "2025-05-14T17:10:32.339Z" }

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/75/0455fa5029507a2150da59db4f165fbc458ff8bb1c4f4d7e8037a14ad421/freezegun-1.5.2.tar.gz", hash = "sha256:a54ae1d2f9c02dbf42e02c18a3ab95ab4295818b549a34dac55592d72a905181", size = 34855, upload-time = "2025-05-24T12:38:47.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/b2/68d4c9b6431121b6b6aa5e04a153cac41dcacc79600ed6e2e7c3382156f5/freezegun-1.5.2-py3-none-any.whl", hash = "sha256:5aaf3ba229cda57afab5bd311f0108d86b6fb119ae89d2cd9c43ec8c1733c85b", size = 18715, upload-time = "2025-05-24T12:38:45.274Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -211,6 +223,7 @@ dependencies = [
 
 [package.dev-dependencies]
 ci = [
+    { name = "freezegun" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
@@ -222,6 +235,7 @@ ci = [
     { name = "types-requests" },
 ]
 dev = [
+    { name = "freezegun" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -240,6 +254,7 @@ lint = [
     { name = "types-requests" },
 ]
 test = [
+    { name = "freezegun" },
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -264,6 +279,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
+    { name = "freezegun", specifier = ">=1.5.2" },
     { name = "hypothesis", specifier = ">=6.135.2" },
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "pytest", specifier = ">=8.4.0" },
@@ -275,6 +291,7 @@ ci = [
     { name = "types-requests", specifier = ">=2.32.0.20250602" },
 ]
 dev = [
+    { name = "freezegun", specifier = ">=1.5.2" },
     { name = "hypothesis", specifier = ">=6.135.2" },
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
@@ -293,6 +310,7 @@ lint = [
     { name = "types-requests", specifier = ">=2.32.0.20250602" },
 ]
 test = [
+    { name = "freezegun", specifier = ">=1.5.2" },
     { name = "hypothesis", specifier = ">=6.135.2" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },


### PR DESCRIPTION
- Adjust the Python version requirement
- Implement PEP 735 dependency groups to replace uv specific dev-dependencies
- Update CI workflows to utilize the new dependency groups
- Update ruff linting rules
- Resolve new linting issues
- Fix tests for log file suffix handling

## Summary by Sourcery

Tidy project configuration and tooling by refining Python version bounds, adopting PEP 735 dependency groups in pyproject.toml, updating CI workflows, adjusting linting settings, and enhancing tests for log file naming.

Enhancements:
- Constrain requires-python to >=3.13,<3.14 and add a private classifier
- Replace flat uv dev-dependencies with PEP 735 dependency-groups (dev, tools, lint, test, ci)
- Expand ruff linting select rules
- Add custom words to cspell configuration

CI:
- Update GitHub Actions workflows to install dependencies via uv sync with appropriate groups

Tests:
- Fix log file suffix handling tests by filtering duplicate .log entries and adding a dedicated multi-log-suffix case