### PR TITLE
chore(pre-commit): Add uv-lock hook to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
       - id: check-toml
       - id: check-yaml
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.7.13
+    hooks:
+      - id: uv-lock
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.11.13


### PR DESCRIPTION
Add the uv-lock hook to the pre-commit setup to ensure `uv.lock` remains up-to-date.

## Summary by Sourcery

CI:
- Add uv-lock hook to pre-commit configuration to enforce up-to-date uv.lock