### PR TITLE
ci: Set pre-commit.ci PRs to auto-merge when tests pass

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -33,6 +33,10 @@ jobs:
         id: assign-owner
         run: gh pr edit "${{env.PR_URL}}" --add-assignee "${{ github.repository_owner }}"
 
+      - name: Set auto-merge when tests pass
+        id: auto-merge
+        run: gh pr merge "${{env.PR_URL}}" --auto --squash
+
   dependabot:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Set auto-merge when tests pass
         id: auto-merge
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: gh pr merge "${{env.PR_URL}}" --auto --squash
 
   dependabot:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the manage-pull-requests GitHub Actions workflow to invoke `gh pr merge --auto --squash` for applicable pull requests.