### PR TITLE
ci: Add missing permission for auto-merge step of pre-commit.ci job

### DIFF
--- a/.github/workflows/manage-pull-requests.yml
+++ b/.github/workflows/manage-pull-requests.yml
@@ -24,6 +24,9 @@ jobs:
   pre-commit-ci:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Add semver:patch label
         id: label-maintenance


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add write permissions for pull requests and contents to the pre-commit-ci GitHub Actions job.